### PR TITLE
Tweaks for accessibility

### DIFF
--- a/app.js
+++ b/app.js
@@ -407,7 +407,7 @@ class JobResult extends LitElement {
   }
 
   fullName(){
-    return `Capture of ${this.result.captureUrl} (Job ${this.result.jobid}, index ${this.result.index})`
+    return `${this.result.userTag ? `Batch "${this.result.userTag }",`: '' } Capture of ${this.result.captureUrl} from ${new Date(this.result.startTime).toLocaleString()}`
   }
 
   async checkSize() {

--- a/app.js
+++ b/app.js
@@ -315,7 +315,7 @@ class WitnessApp extends LitElement {
           <div class="field">
             <label for="tag" class="label">Label (Optional)</label>
             <div class="control">
-              <input id="tag" type="text" class="input" value="" placeholder="My Collection"/>
+              <input id="tag" type="text" class="input" value=""/>
             </div>
           </div>
 
@@ -589,7 +589,7 @@ class JobResult extends LitElement {
   }
 
   render() {
-    const tag = this.result.userTag || this.result.jobid;
+    const tag = this.result.userTag || html `<span aria-hidden="true">-</span><span class="is-sr-only">None</span>`;
 
     return html`
       <div class="columns" @dblclick="${this.onTogglePreview}">

--- a/app.js
+++ b/app.js
@@ -103,9 +103,13 @@ class WitnessApp extends LitElement {
 
   async doUpdateResults() {
     if (!TEST_DATA) {
-      let resp = await fetch(`${this.apiprefix}/captures`);
-      resp = await resp.json();
-      this.results = resp.jobs;
+      let res = await fetch(`${this.apiprefix}/captures`);
+      if (res.status == 200) {
+        res = await res.json();
+        this.results = res.jobs;
+      } else {
+        this.errorMessage = html `Sorry, the list of submitted captures is not available.${this.contactMessage()}`
+      }
     } else {
       this.results = JSON.parse(TEST_DATA).jobs;
     }

--- a/app.js
+++ b/app.js
@@ -464,7 +464,13 @@ class JobResult extends LitElement {
       .column.controls {
         display: flex;
         flex-direction: row;
-        justify-content: flex-start;
+        justify-content: flex-end;
+      }
+
+      @media screen and (max-width: 769px) {
+        .column.controls {
+          justify-content: flex-start;
+        }
       }
 
       .column.controls.success {
@@ -610,7 +616,7 @@ class JobResult extends LitElement {
             <span aria-hidden="true">-</span><span class="is-sr-only">0</span>`}
           </p>
         </div>
-        <div class="column controls ${this.result.status === "Complete" ? "success" : ""} is-2">
+        <div class="column controls ${this.result.status === "Complete" ? "success" : ""} is-3-tablet is-2-desktop">
           ${this.renderControls()}
         </div>
       </div>

--- a/app.js
+++ b/app.js
@@ -43,6 +43,7 @@ class WitnessApp extends LitElement {
     this.submittedUrlsInvalid = false;
 
     this.errorMessage = "";
+    this.successMessage = ""
   }
 
   static get sortKeys() {
@@ -88,6 +89,7 @@ class WitnessApp extends LitElement {
       submittedUrlsInvalid: { type: Boolean },
 
       errorMessage: { type: String },
+      successMessage: { type: String },
     }
   }
 
@@ -187,6 +189,7 @@ class WitnessApp extends LitElement {
     this.submittedUrlsInvalid = false;
     this.fieldErrorMessage = "";
     this.errorMessage = "";
+    this.successMessage = "";
 
     const textArea = this.renderRoot.querySelector("#urls");
     const tagField = this.renderRoot.querySelector("#tag");
@@ -219,6 +222,13 @@ class WitnessApp extends LitElement {
     if (res.status === 200) {
       this.doUpdateResults();
       textArea.value = "";
+
+      // Send keyboard focus to a success message, for a11y.
+      const jobDetails = await res.json();
+      this.successMessage = `Success: ${jobDetails.urls} submitted. JobID: ${jobDetails.jobid}`;
+      await this.updateComplete;
+      this.renderRoot.querySelector("#success-message").focus();
+
     } else {
       this.errorMessage = html `Sorry, an error occurred: capture was not started.${this.contactEmail ? html `<br>Please try again, or <a href="mailto:${this.contactEmail}">contact us</a> for additional assistance.` : ``}`;
     }
@@ -312,6 +322,9 @@ class WitnessApp extends LitElement {
               <span class="error">${this.errorMessage}</span>
               ` : ``}
             </span>
+            ${this.successMessage ? html`
+            <span id="success-message" class="is-sr-only" tabindex="-1">${this.successMessage}</span>
+            ` : ``}
           </div>
         </form>
       </div>

--- a/app.js
+++ b/app.js
@@ -287,6 +287,7 @@ class WitnessApp extends LitElement {
         </form>
       </div>
       ${this.results.length ? html`
+      <h2 class="is-sr-only">Submitted Jobs</h2>
       <div class="sorter">
         <wr-sorter id="captures"
           .defaultKey="startTime"
@@ -532,6 +533,7 @@ class JobResult extends LitElement {
 
     return html`
       <div class="columns" @dblclick="${this.onTogglePreview}">
+        <h3 class="is-sr-only">Capture of ${this.result.captureUrl} (Job ${this.result.jobid}, index ${this.result.index})</h3>
         <div class="column is-1">
           <p class="minihead">Status</p>
           ${this.renderStatus()}

--- a/app.js
+++ b/app.js
@@ -230,7 +230,7 @@ class WitnessApp extends LitElement {
       this.renderRoot.querySelector("#success-message").focus();
 
     } else {
-      this.errorMessage = html `Sorry, an error occurred: capture was not started.${this.contactEmail ? html `<br>Please try again, or <a href="mailto:${this.contactEmail}">contact us</a> for additional assistance.` : ``}`;
+      this.errorMessage = html `Sorry, an error occurred: capture was not started.${this.contactMessage()}`;
     }
   }
 
@@ -263,10 +263,14 @@ class WitnessApp extends LitElement {
 
     const res = await fetch(`${this.apiprefix}/capture/${jobid}/${index}`, {method: "DELETE", headers});
     if (res.status != 200) {
-      this.errorMessage = "Sorry, an error has occured. Capture Not Started";
+      this.errorMessage = html `Sorry, an error occurred: deletion failed.${this.contactMessage()}`;
     } else {
       this.doUpdateResults();
     }
+  }
+
+  contactMessage() {
+    return html `${this.contactEmail ? html `<br>Please try again, or <a href="mailto:${this.contactEmail}">contact us</a> for additional assistance.` : ``}`;
   }
 
   onSortChanged(event) {
@@ -283,7 +287,7 @@ class WitnessApp extends LitElement {
     if (res.status === 200) {
       this.doUpdateResults();
     } else {
-      this.errorMessage = "Sorry, an error has occured. Capture Not Started";
+      this.errorMessage = html `Sorry, an error has occurred: capture not retried.${this.contactMessage()}`;
     }
   }
 

--- a/app.js
+++ b/app.js
@@ -432,7 +432,7 @@ class JobResult extends LitElement {
         vertical-align: middle;
       }
 
-      button.button.is-loading::after {
+      .button.is-loading::after {
         border-color: transparent transparent grey grey !important;
       }
 
@@ -480,18 +480,22 @@ class JobResult extends LitElement {
       case "Complete":
         return html`
         <p>
-          <fa-icon class="check" .svg="${faCheck}"/>
+          <fa-icon class="check" .svg="${faCheck}" aria-hidden="true"></fa-icon>
+          <span class="is-sr-only">Complete</span>
         </p>`;
 
       case "In progress":
         return html`
-        <p><button class="is-loading button in-progress"></button></p>
-        `;
+        <p>
+          <span class="is-loading button in-progress" aria-hidden="true"></span>
+          <span class="is-sr-only">In Progress</span>
+        </p>`;
 
       case "Failed":
         return html`
         <p>
-          <fa-icon class="failed" .svg="${faX}"/>
+          <fa-icon class="failed" .svg="${faX}" aria-hidden="true"></fa-icon>
+          <span class="is-sr-only">Failed</span>
         </p>`;
     }
   }
@@ -499,24 +503,25 @@ class JobResult extends LitElement {
   renderControls() {
     return html`
         ${this.result.status === "Complete" ? html`
-        <a class="preview-toggle" @click="${this.onTogglePreview}">
-          <span class="is-hidden-tablet preview-text">Preview</span>
-          <fa-icon size="1.5em" .svg="${this.showPreview ? faDown : faRight}"/>
+        <a role="button" class="preview-toggle" @click="${this.onTogglePreview}" aria-label="Preview Capture" aria-expanded="${this.showPreview}">
+          <span class="is-hidden-tablet preview-text" aria-hidden="true">Preview</span>
+          <fa-icon size="1.5em" .svg="${this.showPreview ? faDown : faRight}" aria-hidden="true"></fa-icon>
         </a>
-        <a href="${this.result.accessUrl}" class="download" title="Download Capture">
-          <fa-icon .svg="${faDownload}"/>
+        <a href="${this.result.accessUrl}" class="download" aria-label="Download Capture" title="Download Capture">
+          <fa-icon .svg="${faDownload}" aria-hidden="true"></fa-icon>
         </a>` : ``}
 
         ${this.result.status !== "In progress" ? html`
-        <a @click="${this.onRetry}" title="Retry Capture" class="retry">
-          <fa-icon .svg="${faRedo}"></fa-icon>
+        <a role="button" @click="${this.onRetry}" aria-label="Retry Capture" title="Retry Capture" class="retry">
+          <fa-icon .svg="${faRedo}" aria-hidden="true"></fa-icon>
         </a>` : ``}
 
         ${!this.isDeleting ? html`
-          <a @click="${this.onDelete}" title="Delete Capture" class="deleter">
-            <fa-icon .svg="${faDelete}"></fa-icon>
+          <a role="button" @click="${this.onDelete}" aria-label="Delete Capture" title="Delete Capture" class="deleter">
+            <fa-icon .svg="${faDelete}" aria-hidden="true"></fa-icon>
           </a>` :  html`
-          <button class="is-loading button"></button>
+          <span class="is-loading button" aria-hidden="true"></span>
+          <span class="is-sr-only">Deletion In Progress</span>
           `}
         `;
   }
@@ -525,14 +530,14 @@ class JobResult extends LitElement {
     const tag = this.result.userTag || this.result.jobid;
 
     return html`
-      <nav class="columns" @dblclick="${this.onTogglePreview}">
+      <div class="columns" @dblclick="${this.onTogglePreview}">
         <div class="column is-1">
           <p class="minihead">Status</p>
           ${this.renderStatus()}
         </div>
         <div class="column clip is-2">
           <p class="minihead">Label</p>
-          <p title="${tag}">${tag}</p>
+          <p>${tag}</p>
         </div>
         <div class="column is-3">
           <p class="minihead">Start Date</p>
@@ -540,16 +545,18 @@ class JobResult extends LitElement {
         </div>
         <div class="column clip">
           <p class="minihead">URL</p>
-          <p class="url" title="${this.result.captureUrl}">${this.result.captureUrl}</p>
+          <p class="url">${this.result.captureUrl}</p>
         </div>
         <div class="column is-1">
           <p class="minihead">Size</p>
-          <p title="Size">${this.size >= 0 ? prettyBytes(this.size) : "-"}</p>
+          <p>${this.size >= 0 ? prettyBytes(this.size) : html`
+            <span aria-hidden="true">-</span><span class="is-sr-only">0</span>`}
+          </p>
         </div>
         <div class="column controls ${this.result.status === "Complete" ? "success" : ""} is-2">
           ${this.renderControls()}
         </div>
-      </nav>
+      </div>
       ${this.showPreview ? html`
       <div class="preview">
         <replay-web-page

--- a/app.js
+++ b/app.js
@@ -356,6 +356,10 @@ class JobResult extends LitElement {
     }
   }
 
+  fullName(){
+    return `Capture of ${this.result.captureUrl} (Job ${this.result.jobid}, index ${this.result.index})`
+  }
+
   async checkSize() {
     if (this.size >= 0 || this.result.status !== "Complete") {
       return;
@@ -505,7 +509,7 @@ class JobResult extends LitElement {
   renderControls() {
     return html`
       ${!this.isDeleting ? html`
-        <a href="#" role="button" @click="${this.onDelete}" @keyup="${this.clickOnSpacebarPress}" aria-label="Delete Capture" title="Delete Capture" class="deleter">
+        <a href="#" role="button" @click="${this.onDelete}" @keyup="${this.clickOnSpacebarPress}" aria-label="Delete ${this.fullName()}" title="Delete Capture" class="deleter">
           <fa-icon .svg="${faDelete}" aria-hidden="true"></fa-icon>
         </a>` :  html`
         <span class="is-loading button" aria-hidden="true"></span>
@@ -513,15 +517,15 @@ class JobResult extends LitElement {
       `}
 
       ${this.result.status !== "In progress" ? html`
-      <a href="#" role="button" @click="${this.onRetry}" @keyup="${this.clickOnSpacebarPress}" aria-label="Retry Capture" title="Retry Capture" class="retry">
+      <a href="#" role="button" @click="${this.onRetry}" @keyup="${this.clickOnSpacebarPress}" aria-label="Retry ${this.fullName()}" title="Retry Capture" class="retry">
         <fa-icon .svg="${faRedo}" aria-hidden="true"></fa-icon>
       </a>` : ``}
 
       ${this.result.status === "Complete" ? html`
-      <a href="${this.result.accessUrl}" class="download" aria-label="Download Capture" title="Download Capture">
+      <a href="${this.result.accessUrl}" class="download" aria-label="Download ${this.fullName()}" title="Download Capture">
         <fa-icon .svg="${faDownload}" aria-hidden="true"></fa-icon>
       </a>
-      <a href="#" role="button" class="preview-toggle" @click="${this.onTogglePreview}" @keyup="${this.clickOnSpacebarPress}" aria-label="Preview Capture" aria-expanded="${this.showPreview}">
+      <a href="#" role="button" class="preview-toggle" @click="${this.onTogglePreview}" @keyup="${this.clickOnSpacebarPress}" aria-label="Preview ${this.fullName()}" aria-expanded="${this.showPreview}">
         <span class="is-hidden-tablet preview-text" aria-hidden="true">Preview</span>
         <fa-icon size="1.5em" .svg="${this.showPreview ? faDown : faRight}" aria-hidden="true"></fa-icon>
       </a>`: ``}
@@ -533,7 +537,7 @@ class JobResult extends LitElement {
 
     return html`
       <div class="columns" @dblclick="${this.onTogglePreview}">
-        <h3 class="is-sr-only">Capture of ${this.result.captureUrl} (Job ${this.result.jobid}, index ${this.result.index})</h3>
+        <h3 class="is-sr-only">${this.fullName()}</h3>
         <div class="column is-1">
           <p class="minihead">Status</p>
           ${this.renderStatus()}

--- a/app.js
+++ b/app.js
@@ -261,14 +261,14 @@ class WitnessApp extends LitElement {
           ${this.csrftoken ? html`
             <input type="hidden" name="${this.csrftoken_name}" value="${this.csrftoken}"/>` : ``}
           <div class="field">
-          <label class="label">URLs</label>
+            <label for="urls" class="label">URLs</label>
             <div class="control">
               <textarea id="urls" rows="3" required class="textarea is-link" placeholder="Enter one or more URLs on each line"></textarea>
             </div>
           </div>
 
           <div class="field">
-            <label class="label">Label (Optional)</label>
+            <label for="tag" class="label">Label (Optional)</label>
             <div class="control">
               <input id="tag" type="text" class="input" value="My Archive" placeholder="My Archive"/>
             </div>

--- a/app.js
+++ b/app.js
@@ -505,7 +505,7 @@ class JobResult extends LitElement {
   renderControls() {
     return html`
       ${!this.isDeleting ? html`
-        <a href="#" role="button" @click="${this.onDelete}" aria-label="Delete Capture" title="Delete Capture" class="deleter">
+        <a href="#" role="button" @click="${this.onDelete}" @keyup="${this.clickOnSpacebarPress}" aria-label="Delete Capture" title="Delete Capture" class="deleter">
           <fa-icon .svg="${faDelete}" aria-hidden="true"></fa-icon>
         </a>` :  html`
         <span class="is-loading button" aria-hidden="true"></span>
@@ -513,7 +513,7 @@ class JobResult extends LitElement {
       `}
 
       ${this.result.status !== "In progress" ? html`
-      <a href="#" role="button" @click="${this.onRetry}" aria-label="Retry Capture" title="Retry Capture" class="retry">
+      <a href="#" role="button" @click="${this.onRetry}" @keyup="${this.clickOnSpacebarPress}" aria-label="Retry Capture" title="Retry Capture" class="retry">
         <fa-icon .svg="${faRedo}" aria-hidden="true"></fa-icon>
       </a>` : ``}
 
@@ -521,7 +521,7 @@ class JobResult extends LitElement {
       <a href="${this.result.accessUrl}" class="download" aria-label="Download Capture" title="Download Capture">
         <fa-icon .svg="${faDownload}" aria-hidden="true"></fa-icon>
       </a>
-      <a href="#" role="button" class="preview-toggle" @click="${this.onTogglePreview}" aria-label="Preview Capture" aria-expanded="${this.showPreview}">
+      <a href="#" role="button" class="preview-toggle" @click="${this.onTogglePreview}" @keyup="${this.clickOnSpacebarPress}" aria-label="Preview Capture" aria-expanded="${this.showPreview}">
         <span class="is-hidden-tablet preview-text" aria-hidden="true">Preview</span>
         <fa-icon size="1.5em" .svg="${this.showPreview ? faDown : faRight}" aria-hidden="true"></fa-icon>
       </a>`: ``}
@@ -569,6 +569,15 @@ class JobResult extends LitElement {
       ` : html``}
 
     `;
+  }
+
+  clickOnSpacebarPress(event) {
+    // Buttons are expected to respond to both enter/return and spacebar.
+    // If using `<a>` with `role='button'`, assign this handler to keyup.
+    if (event.key == " ") {
+      event.preventDefault();
+      event.target.click();
+    }
   }
 
   onTogglePreview(event) {

--- a/app.js
+++ b/app.js
@@ -568,7 +568,8 @@ class JobResult extends LitElement {
       <div class="preview">
         <replay-web-page
           source="${this.result.accessUrl}"
-          url="${this.result.captureUrl}"></replay-web-page>
+          url="${this.result.captureUrl}">
+        </replay-web-page>
       </div>
       ` : html``}
 
@@ -594,7 +595,6 @@ class JobResult extends LitElement {
     event.preventDefault();
     const detail = this.result;
     this.isDeleting = true;
-
     this.dispatchEvent(new CustomEvent("on-delete", {detail}));
   }
 

--- a/app.js
+++ b/app.js
@@ -505,7 +505,7 @@ class JobResult extends LitElement {
   renderControls() {
     return html`
       ${!this.isDeleting ? html`
-        <a role="button" @click="${this.onDelete}" aria-label="Delete Capture" title="Delete Capture" class="deleter">
+        <a href="#" role="button" @click="${this.onDelete}" aria-label="Delete Capture" title="Delete Capture" class="deleter">
           <fa-icon .svg="${faDelete}" aria-hidden="true"></fa-icon>
         </a>` :  html`
         <span class="is-loading button" aria-hidden="true"></span>
@@ -513,7 +513,7 @@ class JobResult extends LitElement {
       `}
 
       ${this.result.status !== "In progress" ? html`
-      <a role="button" @click="${this.onRetry}" aria-label="Retry Capture" title="Retry Capture" class="retry">
+      <a href="#" role="button" @click="${this.onRetry}" aria-label="Retry Capture" title="Retry Capture" class="retry">
         <fa-icon .svg="${faRedo}" aria-hidden="true"></fa-icon>
       </a>` : ``}
 
@@ -521,7 +521,7 @@ class JobResult extends LitElement {
       <a href="${this.result.accessUrl}" class="download" aria-label="Download Capture" title="Download Capture">
         <fa-icon .svg="${faDownload}" aria-hidden="true"></fa-icon>
       </a>
-      <a role="button" class="preview-toggle" @click="${this.onTogglePreview}" aria-label="Preview Capture" aria-expanded="${this.showPreview}">
+      <a href="#" role="button" class="preview-toggle" @click="${this.onTogglePreview}" aria-label="Preview Capture" aria-expanded="${this.showPreview}">
         <span class="is-hidden-tablet preview-text" aria-hidden="true">Preview</span>
         <fa-icon size="1.5em" .svg="${this.showPreview ? faDown : faRight}" aria-hidden="true"></fa-icon>
       </a>`: ``}
@@ -578,6 +578,7 @@ class JobResult extends LitElement {
   }
 
   onDelete(event) {
+    event.preventDefault();
     const detail = this.result;
     this.isDeleting = true;
 
@@ -585,6 +586,7 @@ class JobResult extends LitElement {
   }
 
   onRetry(event) {
+    event.preventDefault();
     this.dispatchEvent(new CustomEvent("on-retry"));
   }
 }

--- a/app.js
+++ b/app.js
@@ -68,7 +68,7 @@ class WitnessApp extends LitElement {
   static get properties() {
     return {
       apiprefix: { type: String },
-      
+
       results: { type: Array },
       sortedResults: { type: Array},
 
@@ -90,7 +90,7 @@ class WitnessApp extends LitElement {
     }, 5000);
   }
 
-  async doUpdateResults() { 
+  async doUpdateResults() {
     if (!TEST_DATA) {
       let resp = await fetch(`${this.apiprefix}/captures`);
       resp = await resp.json();
@@ -121,7 +121,7 @@ class WitnessApp extends LitElement {
       .result:nth-child(odd) {
         background-color: #eee;
       }
-      
+
       .result:nth-child(even) {
         background-color: #ddd;
       }
@@ -361,7 +361,7 @@ class JobResult extends LitElement {
     }
 
     const res = await fetch(this.result.accessUrl, {method: "HEAD"});
-    
+
     if (res.status === 200) {
       this.props.size = Number(res.headers.get("Content-Length"));
       this.result.size = this.props.size;

--- a/app.js
+++ b/app.js
@@ -408,7 +408,7 @@ class JobResult extends LitElement {
 
       .column.controls {
         display: flex;
-        flex-direction: row-reverse;
+        flex-direction: row;
         justify-content: flex-start;
       }
 
@@ -458,6 +458,7 @@ class JobResult extends LitElement {
 
       .preview-toggle fa-icon {
         margin: 0px;
+        margin-top: -2px;
       }
 
       .check {
@@ -502,28 +503,28 @@ class JobResult extends LitElement {
 
   renderControls() {
     return html`
-        ${this.result.status === "Complete" ? html`
-        <a role="button" class="preview-toggle" @click="${this.onTogglePreview}" aria-label="Preview Capture" aria-expanded="${this.showPreview}">
-          <span class="is-hidden-tablet preview-text" aria-hidden="true">Preview</span>
-          <fa-icon size="1.5em" .svg="${this.showPreview ? faDown : faRight}" aria-hidden="true"></fa-icon>
-        </a>
-        <a href="${this.result.accessUrl}" class="download" aria-label="Download Capture" title="Download Capture">
-          <fa-icon .svg="${faDownload}" aria-hidden="true"></fa-icon>
-        </a>` : ``}
+      ${!this.isDeleting ? html`
+        <a role="button" @click="${this.onDelete}" aria-label="Delete Capture" title="Delete Capture" class="deleter">
+          <fa-icon .svg="${faDelete}" aria-hidden="true"></fa-icon>
+        </a>` :  html`
+        <span class="is-loading button" aria-hidden="true"></span>
+        <span class="is-sr-only">Deletion In Progress</span>
+      `}
 
-        ${this.result.status !== "In progress" ? html`
-        <a role="button" @click="${this.onRetry}" aria-label="Retry Capture" title="Retry Capture" class="retry">
-          <fa-icon .svg="${faRedo}" aria-hidden="true"></fa-icon>
-        </a>` : ``}
+      ${this.result.status !== "In progress" ? html`
+      <a role="button" @click="${this.onRetry}" aria-label="Retry Capture" title="Retry Capture" class="retry">
+        <fa-icon .svg="${faRedo}" aria-hidden="true"></fa-icon>
+      </a>` : ``}
 
-        ${!this.isDeleting ? html`
-          <a role="button" @click="${this.onDelete}" aria-label="Delete Capture" title="Delete Capture" class="deleter">
-            <fa-icon .svg="${faDelete}" aria-hidden="true"></fa-icon>
-          </a>` :  html`
-          <span class="is-loading button" aria-hidden="true"></span>
-          <span class="is-sr-only">Deletion In Progress</span>
-          `}
-        `;
+      ${this.result.status === "Complete" ? html`
+      <a href="${this.result.accessUrl}" class="download" aria-label="Download Capture" title="Download Capture">
+        <fa-icon .svg="${faDownload}" aria-hidden="true"></fa-icon>
+      </a>
+      <a role="button" class="preview-toggle" @click="${this.onTogglePreview}" aria-label="Preview Capture" aria-expanded="${this.showPreview}">
+        <span class="is-hidden-tablet preview-text" aria-hidden="true">Preview</span>
+        <fa-icon size="1.5em" .svg="${this.showPreview ? faDown : faRight}" aria-hidden="true"></fa-icon>
+      </a>`: ``}
+    `;
   }
 
   render() {

--- a/assets/ui.scss
+++ b/assets/ui.scss
@@ -1,5 +1,8 @@
 @charset "utf-8";
 
+// Colors
+$orange: #DD671A;
+
 // Set placeholder contrast to ~4.5:1 for WCAG AA compliance
 $input-placeholder-color: #757575;
 $input-disabled-placeholder-color: #707070;
@@ -8,6 +11,11 @@ $input-disabled-placeholder-color: #707070;
 }
 
 @import "node_modules/bulma/bulma";
+
+// focus/hover styles for buttons
+.button.is-link:focus, .button.is-link:hover {
+  background-color: $orange;
+}
 
 :host {
   font-size: $body-size;

--- a/assets/ui.scss
+++ b/assets/ui.scss
@@ -1,5 +1,12 @@
 @charset "utf-8";
 
+// Set placeholder contrast to ~4.5:1 for WCAG AA compliance
+$input-placeholder-color: #757575;
+$input-disabled-placeholder-color: #707070;
+.input::placeholder, .textarea::placeholder, .select select::placeholder {
+    opacity: 1;
+}
+
 @import "node_modules/bulma/bulma";
 
 :host {


### PR DESCRIPTION
This PR touches a lot of lines of code, but if you look at the individual commits, which are pretty small, the changes will seem much less extensive...

With this merged:
- I believe this repo's UI will be keyboard operable and its elements will be clearly labeled for people using screen readers; I'll move on next to the replayweb.page repo, which includes some of components used here: the sorter, the previewer, etc.
- I tweaked form validation and error display so that field validation error messages are programmatically associated with the invalid input fields in the expected way, and other error messages are announced when they are triggered. The field-level error is styled to match the Bulma.io examples; the general error messages are styled the same way as before.
- I added a little focus handling: on URLs field validation error, focus is moved to the field for correction; on successful submission, focus is moved to a success message so screen reader users can tell their action had effect.
- I did a little work with color contrast and on-focus indicators.... but honestly not a lot, because I'm guessing we'll find someone with a keen design eye to take a pass through... and it will make more sense to adjust colors afterwards.

On the way, I tweaked the error messages a little, and added the option to specify an email address users can contact to report errors.... But both are peripheral and certainly aren't an essential part of the PR.

Still to do, at some point: I have not tested against a fully-functional, live capture server. 
- what happens to keyboard focus if you delete or refresh a capture?
- what happens to keyboard focus if a capture expires while you are focused on it?
- should we be announcing the number of captures in the list, each refresh?
- is the "full name" useful, despite being inscrutable? how else could be make the list more navigable?

But, I think this ought to do it for a first pass.